### PR TITLE
Harmonized usage of install dir parameter for m8prcsvr and m8refsvr

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Each plugin has its own installation script and documentation. Navigate to the s
 git clone https://github.com/laplaque/instana_plugins.git
 cd instana_plugins
 
-# Install specific plugins
+# Install specific plugins with default settings
 cd m8mulprc
 sudo ./install-instana-m8mulprc-plugin.sh
 
@@ -134,6 +134,31 @@ sudo ./install-instana-m8refsvr-plugin.sh
 cd ../mstrsvr
 sudo ./install-instana-mstrsvr-plugin.sh
 ```
+
+### Installation Options
+
+All plugin installation scripts now support the following command-line options:
+
+- `-d, --directory DIR` : Specify a custom installation directory
+
+  ```bash
+  # Example: Install to a custom directory
+  sudo ./install-instana-m8mulprc-plugin.sh -d /path/to/custom/directory
+  ```
+
+- `-r, --restart` : Start the service immediately after installation
+
+  ```bash
+  # Example: Install and start the service
+  sudo ./install-instana-m8refsvr-plugin.sh -r
+  ```
+
+- `-h, --help` : Show help message and exit
+
+  ```bash
+  # Example: Show help message
+  ./install-instana-m8prcsvr-plugin.sh --help
+  ```
 
 ### Permissions and Elevated Rights
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,20 @@
 # Release Notes
 
+## Version 0.0.11 (2025-05-08)
+
+### feat: Added custom installation directory support for all plugins
+
+- Added `-d/--directory` parameter to all plugin installation scripts for specifying custom installation directories
+- Updated m8refsvr/install-instana-m8refsvr-plugin.sh to support the `-d` parameter
+- Updated m8prcsvr/install-instana-m8prcsvr-plugin.sh to support the `-d` parameter
+- Added `-r/--restart` parameter for consistent service control across all plugins
+- Updated documentation in affected README files:
+  - m8refsvr/README.md
+  - m8prcsvr/README.md
+  - main README.md
+- Ensured all plugins now have consistent command-line parameters and behavior
+- Improved flexibility for deployments in non-standard environments
+
 ## Version 0.0.10 (2025-04-25)
 
 ### feat: Added M8PrcSvr plugin

--- a/TAG_v0.0.11.md
+++ b/TAG_v0.0.11.md
@@ -1,0 +1,14 @@
+# v0.0.11 Release
+
+This tag marks the release of version 0.0.11 of the Instana Plugins Collection.
+
+## Changes in this release
+
+- Added `-d/--directory` parameter to all plugin installation scripts for specifying custom installation directories
+- Updated m8refsvr/install-instana-m8refsvr-plugin.sh to support the `-d` parameter
+- Updated m8prcsvr/install-instana-m8prcsvr-plugin.sh to support the `-d` parameter
+- Added `-r/--restart` parameter for consistent service control across all plugins
+- Updated documentation in affected README files
+- Ensured all plugins now have consistent command-line parameters and behavior
+
+This release improves installation flexibility across all plugins, enabling users to install sensors in custom locations, particularly useful for installations with non-standard paths.

--- a/m8prcsvr/README.md
+++ b/m8prcsvr/README.md
@@ -4,11 +4,31 @@ This sensor monitors the MicroStrategy M8PrcSvr process and reports metrics to I
 
 ## Installation
 
-Run the installation script:
+Run the installation script with default settings:
 
 ```bash
-./install-instana-m8prcsvr-plugin.sh
+sudo ./install-instana-m8prcsvr-plugin.sh
 ```
+
+Or specify a custom installation directory:
+
+```bash
+sudo ./install-instana-m8prcsvr-plugin.sh -d /path/to/custom/directory
+```
+
+For all available options:
+
+```bash
+sudo ./install-instana-m8prcsvr-plugin.sh --help
+```
+
+### Installation Options
+
+The installation script supports these command-line options:
+
+- `-d, --directory DIR` : Specify a custom installation directory (default: `/opt/instana/agent/plugins/custom_sensors/microstrategy_m8prcsvr`)
+- `-r, --restart` : Start the service immediately after installation
+- `-h, --help` : Show help message and exit
 
 ## Configuration
 

--- a/m8prcsvr/install-instana-m8prcsvr-plugin.sh
+++ b/m8prcsvr/install-instana-m8prcsvr-plugin.sh
@@ -3,16 +3,86 @@
 
 set -e
 
+# Default installation directories
+DEFAULT_INSTANA_DIR="/opt/instana/agent"
+DEFAULT_PLUGIN_DIR="${DEFAULT_INSTANA_DIR}/plugins/custom_sensors/microstrategy_m8prcsvr"
+
+# Define usage function
+function show_usage {
+    echo "Usage: $0 [OPTIONS]"
+    echo "Install the MicroStrategy M8PrcSvr monitoring plugin for Instana"
+    echo ""
+    echo "Options:"
+    echo "  -d, --directory DIR    Installation directory (default: ${DEFAULT_PLUGIN_DIR})"
+    echo "  -r, --restart          Restart Instana agent after installation"
+    echo "  -h, --help             Show this help message and exit"
+}
+
+# Parse command line arguments
+INSTALL_DIR=$DEFAULT_PLUGIN_DIR
+RESTART_AGENT=false
+
+while [[ $# -gt 0 ]]; do
+    key="$1"
+    case $key in
+        -d|--directory)
+            INSTALL_DIR="$2"
+            shift 2
+            ;;
+        -r|--restart)
+            RESTART_AGENT=true
+            shift
+            ;;
+        -h|--help)
+            show_usage
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown option: $1"
+            show_usage
+            exit 1
+            ;;
+    esac
+done
+
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 PARENT_DIR="$( dirname "$SCRIPT_DIR" )"
+COMMON_DIR="${INSTALL_DIR}/common"
 
-echo "Installing M8PrcSvr plugin..."
+echo "Installing M8PrcSvr plugin to ${INSTALL_DIR}..."
 
 # Check if Python 3 is installed
 if ! command -v python3 &> /dev/null; then
     echo "Python 3 is required but not installed. Please install Python 3 and try again."
     exit 1
 fi
+
+# Create plugin directories
+echo "Creating plugin directories..."
+mkdir -p "${INSTALL_DIR}"
+mkdir -p "${COMMON_DIR}"
+
+# Copy plugin files
+echo "Copying plugin files..."
+cp "${SCRIPT_DIR}/sensor.py" "${INSTALL_DIR}/"
+cp "${SCRIPT_DIR}/plugin.json" "${INSTALL_DIR}/"
+
+# Copy common files
+echo "Copying common files..."
+cp "${PARENT_DIR}/common/process_monitor.py" "${COMMON_DIR}/"
+cp "${PARENT_DIR}/common/otel_connector.py" "${COMMON_DIR}/"
+cp "${PARENT_DIR}/common/base_sensor.py" "${COMMON_DIR}/"
+cp "${PARENT_DIR}/common/logging_config.py" "${COMMON_DIR}/"
+cp "${PARENT_DIR}/common/__init__.py" "${COMMON_DIR}/"
+
+# Create __init__.py if it doesn't exist
+touch "${INSTALL_DIR}/__init__.py"
+
+# Set permissions
+echo "Setting permissions..."
+chmod 755 "${INSTALL_DIR}/sensor.py"
+chmod 644 "${INSTALL_DIR}/plugin.json"
+chmod 644 "${COMMON_DIR}"/*.py
 
 # Install dependencies
 echo "Installing dependencies..."
@@ -30,20 +100,27 @@ Description=Instana M8PrcSvr Sensor
 After=network.target
 
 [Service]
-ExecStart=/usr/bin/python3 $SCRIPT_DIR/sensor.py
+ExecStart=/usr/bin/python3 ${INSTALL_DIR}/sensor.py
 Restart=always
 User=root
 Environment=PYTHONUNBUFFERED=1
+Environment="PYTHONPATH=${INSTALL_DIR}"
 
 [Install]
 WantedBy=multi-user.target
 EOF
 
-    echo "Enabling and starting service..."
+    echo "Enabling service..."
     systemctl daemon-reload
     systemctl enable instana-m8prcsvr-sensor.service
-    systemctl start instana-m8prcsvr-sensor.service
+    
+    # Start the service if requested
+    if [ "$RESTART_AGENT" = true ]; then
+        echo "Starting service..."
+        systemctl start instana-m8prcsvr-sensor.service
+    fi
 fi
 
 echo "Installation complete!"
+echo "M8PrcSvr plugin has been installed to ${INSTALL_DIR}"
 echo "To check the status of the service, run: systemctl status instana-m8prcsvr-sensor.service"

--- a/m8refsvr/README.md
+++ b/m8refsvr/README.md
@@ -46,9 +46,23 @@ Use the installation script to easily deploy the plugin:
 git clone https://github.com/laplaque/instana_plugins.git
 cd instana_plugins/m8refsvr
 
-# Run the installer script
+# Run the installer script with default settings
 sudo ./install-instana-m8refsvr-plugin.sh
+
+# Or specify a custom installation directory
+sudo ./install-instana-m8refsvr-plugin.sh -d /path/to/custom/directory
+
+# For all available options
+sudo ./install-instana-m8refsvr-plugin.sh --help
 ```
+
+### Installation Options
+
+The installation script supports these command-line options:
+
+- `-d, --directory DIR` : Specify a custom installation directory (default: `/opt/instana/agent/plugins/custom_sensors/microstrategy_m8refsvr`)
+- `-r, --restart` : Start the service immediately after installation
+- `-h, --help` : Show help message and exit
 
 ### Permissions Requirements
 

--- a/m8refsvr/install-instana-m8refsvr-plugin.sh
+++ b/m8refsvr/install-instana-m8refsvr-plugin.sh
@@ -3,10 +3,48 @@
 
 set -e
 
-# Default installation directory
-INSTALL_DIR="/opt/instana/agent/plugins/custom_sensors"
-PLUGIN_NAME="microstrategy_m8refsvr"
-PLUGIN_DIR="${INSTALL_DIR}/${PLUGIN_NAME}"
+# Default installation directories
+DEFAULT_INSTANA_DIR="/opt/instana/agent"
+DEFAULT_PLUGIN_DIR="${DEFAULT_INSTANA_DIR}/plugins/custom_sensors/microstrategy_m8refsvr"
+
+# Define usage function
+function show_usage {
+    echo "Usage: $0 [OPTIONS]"
+    echo "Install the MicroStrategy M8RefSvr monitoring plugin for Instana"
+    echo ""
+    echo "Options:"
+    echo "  -d, --directory DIR    Installation directory (default: ${DEFAULT_PLUGIN_DIR})"
+    echo "  -r, --restart          Restart Instana agent after installation"
+    echo "  -h, --help             Show this help message and exit"
+}
+
+# Parse command line arguments
+INSTALL_DIR=$DEFAULT_PLUGIN_DIR
+RESTART_AGENT=false
+
+while [[ $# -gt 0 ]]; do
+    key="$1"
+    case $key in
+        -d|--directory)
+            INSTALL_DIR="$2"
+            shift 2
+            ;;
+        -r|--restart)
+            RESTART_AGENT=true
+            shift
+            ;;
+        -h|--help)
+            show_usage
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown option: $1"
+            show_usage
+            exit 1
+            ;;
+    esac
+done
+
 COMMON_DIR="${INSTALL_DIR}/common"
 
 # Check if running as root
@@ -15,31 +53,37 @@ if [ "$EUID" -ne 0 ]; then
   exit 1
 fi
 
+echo "Installing M8RefSvr plugin to ${INSTALL_DIR}..."
+
 # Create plugin directories
 echo "Creating plugin directories..."
-mkdir -p "${PLUGIN_DIR}"
+mkdir -p "${INSTALL_DIR}"
 mkdir -p "${COMMON_DIR}"
+
+# Get the directory of this script
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+PARENT_DIR="$( dirname "$SCRIPT_DIR" )"
 
 # Copy plugin files
 echo "Copying plugin files..."
-cp "$(dirname "$0")/sensor.py" "${PLUGIN_DIR}/"
-cp "$(dirname "$0")/plugin.json" "${PLUGIN_DIR}/"
+cp "${SCRIPT_DIR}/sensor.py" "${INSTALL_DIR}/"
+cp "${SCRIPT_DIR}/plugin.json" "${INSTALL_DIR}/"
 
 # Copy common files
 echo "Copying common files..."
-cp "$(dirname "$0")/../common/process_monitor.py" "${COMMON_DIR}/"
-cp "$(dirname "$0")/../common/otel_connector.py" "${COMMON_DIR}/"
-cp "$(dirname "$0")/../common/base_sensor.py" "${COMMON_DIR}/"
-cp "$(dirname "$0")/../common/logging_config.py" "${COMMON_DIR}/"
-cp "$(dirname "$0")/../common/__init__.py" "${COMMON_DIR}/"
+cp "${PARENT_DIR}/common/process_monitor.py" "${COMMON_DIR}/"
+cp "${PARENT_DIR}/common/otel_connector.py" "${COMMON_DIR}/"
+cp "${PARENT_DIR}/common/base_sensor.py" "${COMMON_DIR}/"
+cp "${PARENT_DIR}/common/logging_config.py" "${COMMON_DIR}/"
+cp "${PARENT_DIR}/common/__init__.py" "${COMMON_DIR}/"
 
 # Create __init__.py if it doesn't exist
-touch "${PLUGIN_DIR}/__init__.py"
+touch "${INSTALL_DIR}/__init__.py"
 
 # Set permissions
 echo "Setting permissions..."
-chmod 755 "${PLUGIN_DIR}/sensor.py"
-chmod 644 "${PLUGIN_DIR}/plugin.json"
+chmod 755 "${INSTALL_DIR}/sensor.py"
+chmod 644 "${INSTALL_DIR}/plugin.json"
 chmod 644 "${COMMON_DIR}"/*.py
 
 # Create systemd service file
@@ -55,7 +99,7 @@ After=network.target instana-agent.service
 Type=simple
 User=root
 Environment="PYTHONPATH=${INSTALL_DIR}"
-ExecStart=${PLUGIN_DIR}/sensor.py
+ExecStart=${INSTALL_DIR}/sensor.py
 Restart=always
 RestartSec=10
 
@@ -67,8 +111,13 @@ EOF
 echo "Configuring systemd service..."
 systemctl daemon-reload
 systemctl enable instana-m8refsvr-sensor.service
-systemctl start instana-m8refsvr-sensor.service
+
+# Start the service if requested or by default
+if [ "$RESTART_AGENT" = true ]; then
+    echo "Starting service..."
+    systemctl start instana-m8refsvr-sensor.service
+fi
 
 echo "Installation complete!"
-echo "M8RefSvr plugin has been installed and started."
+echo "M8RefSvr plugin has been installed to ${INSTALL_DIR}"
 echo "Check status with: systemctl status instana-m8refsvr-sensor.service"


### PR DESCRIPTION
# Description

This PR adds the `-d/--directory` parameter to all plugin installation scripts to allow specifying a custom installation directory. Previously, only some plugins supported this parameter, while others had hardcoded installation paths.

Changes include:

- Updated m8refsvr/install-instana-m8refsvr-plugin.sh to support the `-d` parameter
- Updated m8prcsvr/install-instana-m8prcsvr-plugin.sh to support the `-d` parameter
- Updated documentation in all affected README files:
  - m8refsvr/README.md
  - m8prcsvr/README.md
  - main README.md

Now all plugins consistently support the same command-line parameters for installation, making the user experience more predictable and allowing for more flexible deployments.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If this is a merge to master, I will create a version tag (v*.*.*)
- [x] The version tag will be higher than the previous version

## Tag Information
<!-- If merging to master, include the tag you plan to create after merge -->
Planned tag: v0.0.11