### PR TITLE
Update all sensor.py version tags to match project version 0.0.11

### DIFF
--- a/m8mulprc/sensor.py
+++ b/m8mulprc/sensor.py
@@ -6,7 +6,7 @@ MIT License
 Copyright (c) 2025 laplaque/instana_plugins Contributors
 
 This file is part of the Instana Plugins collection.
-Version: 0.0.6
+Version: 0.0.11
 """
 import sys
 import os
@@ -18,8 +18,7 @@ from common.base_sensor import run_sensor
 # Define the process name with proper capitalization
 PROCESS_NAME = "M8MulPrc"
 PLUGIN_NAME = "com.instana.plugin.python.microstrategy_m8mulprc"
-VERSION = "0.0.8"
+VERSION = "0.0.11"
 
 if __name__ == "__main__":
     run_sensor(PROCESS_NAME, PLUGIN_NAME, VERSION)
-

--- a/m8prcsvr/sensor.py
+++ b/m8prcsvr/sensor.py
@@ -3,6 +3,7 @@
 M8PrcSvr Sensor
 
 This module monitors the MicroStrategy M8PrcSvr process and reports metrics to Instana.
+Version: 0.0.11
 """
 
 import sys
@@ -15,7 +16,7 @@ from common.base_sensor import run_sensor
 
 PROCESS_NAME = "M8PrcSvr"
 PLUGIN_NAME = "com.instana.plugin.python.microstrategy_m8prcsvr"
-VERSION = "0.0.10"
+VERSION = "0.0.11"
 
 if __name__ == "__main__":
     run_sensor(PROCESS_NAME, PLUGIN_NAME, VERSION)

--- a/m8refsvr/sensor.py
+++ b/m8refsvr/sensor.py
@@ -6,7 +6,7 @@ MIT License
 Copyright (c) 2025 laplaque/instana_plugins Contributors
 
 This file is part of the Instana Plugins collection.
-Version: 0.0.6
+Version: 0.0.11
 """
 import sys
 import os
@@ -18,7 +18,7 @@ from common.base_sensor import run_sensor
 # Define the process name with proper capitalization
 PROCESS_NAME = "M8RefSvr"
 PLUGIN_NAME = "com.instana.plugin.python.microstrategy_m8refsvr"
-VERSION = "0.0.9"
+VERSION = "0.0.11"
 
 if __name__ == "__main__":
     run_sensor(PROCESS_NAME, PLUGIN_NAME, VERSION)

--- a/mstrsvr/sensor.py
+++ b/mstrsvr/sensor.py
@@ -6,7 +6,7 @@ MIT License
 Copyright (c) 2025 laplaque/instana_plugins Contributors
 
 This file is part of the Instana Plugins collection.
-Version: 0.0.6
+Version: 0.0.11
 """
 import sys
 import os
@@ -18,8 +18,7 @@ from common.base_sensor import run_sensor
 # Define the process name with proper capitalization
 PROCESS_NAME = "MSTRSvr"
 PLUGIN_NAME = "com.instana.plugin.python.microstrategy_mstrsvr"
-VERSION = "0.0.8"
+VERSION = "0.0.11"
 
 if __name__ == "__main__":
     run_sensor(PROCESS_NAME, PLUGIN_NAME, VERSION)
-


### PR DESCRIPTION
# fix: Update all sensor.py version tags to match project version 0.0.11

## Description
This PR updates all sensor.py files to use the consistent version tag of 0.0.11, matching the current project version in RELEASE_NOTES.md. The following changes were made:

- **m8refsvr/sensor.py**:
  - Changed Version comment: 0.0.6 → 0.0.11
  - Changed VERSION variable: 0.0.9 → 0.0.11

- **m8mulprc/sensor.py**:
  - Changed Version comment: 0.0.6 → 0.0.11
  - Changed VERSION variable: 0.0.8 → 0.0.11

- **m8prcsvr/sensor.py**:
  - Added Version comment: 0.0.11
  - Changed VERSION variable: 0.0.10 → 0.0.11

- **mstrsvr/sensor.py**:
  - Changed Version comment: 0.0.6 → 0.0.11
  - Changed VERSION variable: 0.0.8 → 0.0.11

This ensures consistent version reporting in logs and correct version information for troubleshooting.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [X] If this is a merge to master, I will create a version tag (v*.*.*)
- [ ] The version tag will be higher than the previous version

## Tag Information
Planned tag: v0.0.11
