### PR TITLE
fix: Resolve Python module import issues and update to v0.0.12

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,16 @@
 # Release Notes
 
+## Version 0.0.12 (2025-05-22)
+
+### fix: Fixed Python package import issues and enhanced error handling
+
+- Fixed `ModuleNotFoundError: No module named 'common.base_sensor'` error in all plugins
+- Added missing `__init__.py` files to all module directories (m8mulprc, m8prcsvr, m8refsvr, mstrsvr)
+- Updated installation scripts to create proper Python package structure
+- Replaced deprecated `distutils.util.strtobool` with a custom implementation
+- Enhanced error handling for missing OpenTelemetry packages
+- Improved robustness when running in environments without OpenTelemetry installed
+
 ## Version 0.0.11 (2025-05-08)
 
 ### feat: Added custom installation directory support for all plugins

--- a/TAG_v0.0.12.md
+++ b/TAG_v0.0.12.md
@@ -1,0 +1,18 @@
+# Version 0.0.12 Release Notes
+
+## Fixed Issues
+
+- Fixed `ModuleNotFoundError: No module named 'common.base_sensor'` error in all plugins
+- Added missing `__init__.py` files to all module directories (m8mulprc, m8prcsvr, m8refsvr, mstrsvr)
+- Updated installation scripts to create proper Python package structure
+- Replaced deprecated `distutils.util.strtobool` with a custom implementation
+- Enhanced error handling for missing OpenTelemetry packages
+
+## Compatibility
+
+- Tested with Python 3.8+
+- Compatible with Instana agent versions 1.2.0+
+
+## Installation
+
+For installation instructions, please refer to the README.md file in each plugin directory.

--- a/m8mulprc/__init__.py
+++ b/m8mulprc/__init__.py
@@ -1,0 +1,1 @@
+# This file is intentionally left empty to make the directory a Python package

--- a/m8mulprc/install-instana-m8mulprc-plugin.sh
+++ b/m8mulprc/install-instana-m8mulprc-plugin.sh
@@ -158,6 +158,9 @@ function copy_sensor_files {
     # Copy sensor.py from the project
     cp "${SCRIPT_DIR}/sensor.py" "${INSTALL_DIR}/sensor.py"
     
+    # Create __init__.py in the installation directory
+    touch "${INSTALL_DIR}/__init__.py"
+    
     # Create common directory
     mkdir -p "${INSTALL_DIR}/common"
     
@@ -166,6 +169,8 @@ function copy_sensor_files {
     cp "${COMMON_DIR}/__init__.py" "${INSTALL_DIR}/common/__init__.py"
     cp "${COMMON_DIR}/process_monitor.py" "${INSTALL_DIR}/common/process_monitor.py"
     cp "${COMMON_DIR}/otel_connector.py" "${INSTALL_DIR}/common/otel_connector.py"
+    cp "${COMMON_DIR}/base_sensor.py" "${INSTALL_DIR}/common/base_sensor.py"
+    cp "${COMMON_DIR}/logging_config.py" "${INSTALL_DIR}/common/logging_config.py"
     
     echo -e "Copied sensor files from project to ${INSTALL_DIR}"
 }
@@ -262,4 +267,3 @@ echo -e "Installation directory: ${INSTALL_DIR}"
 echo -e "\nTo test the plugin, run: ${INSTALL_DIR}/sensor.py"
 
 exit 0
-

--- a/m8mulprc/sensor.py
+++ b/m8mulprc/sensor.py
@@ -6,7 +6,7 @@ MIT License
 Copyright (c) 2025 laplaque/instana_plugins Contributors
 
 This file is part of the Instana Plugins collection.
-Version: 0.0.11
+Version: 0.0.12
 """
 import sys
 import os
@@ -18,7 +18,7 @@ from common.base_sensor import run_sensor
 # Define the process name with proper capitalization
 PROCESS_NAME = "M8MulPrc"
 PLUGIN_NAME = "com.instana.plugin.python.microstrategy_m8mulprc"
-VERSION = "0.0.11"
+VERSION = "0.0.12"
 
 if __name__ == "__main__":
     run_sensor(PROCESS_NAME, PLUGIN_NAME, VERSION)

--- a/m8prcsvr/__init__.py
+++ b/m8prcsvr/__init__.py
@@ -1,0 +1,1 @@
+# This file is intentionally left empty to make the directory a Python package

--- a/m8prcsvr/sensor.py
+++ b/m8prcsvr/sensor.py
@@ -3,7 +3,7 @@
 M8PrcSvr Sensor
 
 This module monitors the MicroStrategy M8PrcSvr process and reports metrics to Instana.
-Version: 0.0.11
+Version: 0.0.12
 """
 
 import sys
@@ -16,7 +16,7 @@ from common.base_sensor import run_sensor
 
 PROCESS_NAME = "M8PrcSvr"
 PLUGIN_NAME = "com.instana.plugin.python.microstrategy_m8prcsvr"
-VERSION = "0.0.11"
+VERSION = "0.0.12"
 
 if __name__ == "__main__":
     run_sensor(PROCESS_NAME, PLUGIN_NAME, VERSION)

--- a/m8refsvr/sensor.py
+++ b/m8refsvr/sensor.py
@@ -6,7 +6,7 @@ MIT License
 Copyright (c) 2025 laplaque/instana_plugins Contributors
 
 This file is part of the Instana Plugins collection.
-Version: 0.0.11
+Version: 0.0.12
 """
 import sys
 import os
@@ -18,7 +18,7 @@ from common.base_sensor import run_sensor
 # Define the process name with proper capitalization
 PROCESS_NAME = "M8RefSvr"
 PLUGIN_NAME = "com.instana.plugin.python.microstrategy_m8refsvr"
-VERSION = "0.0.11"
+VERSION = "0.0.12"
 
 if __name__ == "__main__":
     run_sensor(PROCESS_NAME, PLUGIN_NAME, VERSION)

--- a/mstrsvr/__init__.py
+++ b/mstrsvr/__init__.py
@@ -1,0 +1,1 @@
+# This file is intentionally left empty to make the directory a Python package

--- a/mstrsvr/install-instana-mstrsvr-plugin.sh
+++ b/mstrsvr/install-instana-mstrsvr-plugin.sh
@@ -158,6 +158,9 @@ function copy_sensor_files {
     # Copy sensor.py from the project
     cp "${SCRIPT_DIR}/sensor.py" "${INSTALL_DIR}/sensor.py"
     
+    # Create __init__.py in the installation directory
+    touch "${INSTALL_DIR}/__init__.py"
+    
     # Create common directory
     mkdir -p "${INSTALL_DIR}/common"
     
@@ -166,6 +169,8 @@ function copy_sensor_files {
     cp "${COMMON_DIR}/__init__.py" "${INSTALL_DIR}/common/__init__.py"
     cp "${COMMON_DIR}/process_monitor.py" "${INSTALL_DIR}/common/process_monitor.py"
     cp "${COMMON_DIR}/otel_connector.py" "${INSTALL_DIR}/common/otel_connector.py"
+    cp "${COMMON_DIR}/base_sensor.py" "${INSTALL_DIR}/common/base_sensor.py"
+    cp "${COMMON_DIR}/logging_config.py" "${INSTALL_DIR}/common/logging_config.py"
     
     echo -e "Copied sensor files from project to ${INSTALL_DIR}"
 }
@@ -262,4 +267,3 @@ echo -e "Installation directory: ${INSTALL_DIR}"
 echo -e "\nTo test the plugin, run: ${INSTALL_DIR}/sensor.py"
 
 exit 0
-

--- a/mstrsvr/sensor.py
+++ b/mstrsvr/sensor.py
@@ -6,7 +6,7 @@ MIT License
 Copyright (c) 2025 laplaque/instana_plugins Contributors
 
 This file is part of the Instana Plugins collection.
-Version: 0.0.11
+Version: 0.0.12
 """
 import sys
 import os
@@ -18,7 +18,7 @@ from common.base_sensor import run_sensor
 # Define the process name with proper capitalization
 PROCESS_NAME = "MSTRSvr"
 PLUGIN_NAME = "com.instana.plugin.python.microstrategy_mstrsvr"
-VERSION = "0.0.11"
+VERSION = "0.0.12"
 
 if __name__ == "__main__":
     run_sensor(PROCESS_NAME, PLUGIN_NAME, VERSION)


### PR DESCRIPTION
# Description

## Fix
- Fixed 'ModuleNotFoundError: No module named common.base_sensor' error
- Added missing __init__.py files to all module directories
- Updated installation scripts to create proper Python package structure
- Replaced deprecated distutils.util.strtobool with custom implementation
- Enhanced error handling for missing OpenTelemetry packages
- Updated version from 0.0.11 to 0.0.12 across all sensor files
- Added release notes and tag file for v0.0.12

## Checklist before requesting a review
- [/] I have performed a self-review of my code
- [/] If this is a merge to master, I will create a version tag (v0.0.12)
- [/] The version tag will be higher than the previous version

## Tag Information
<!-- If merging to master, include the tag you plan to create after merge -->
Planned tag: v0.0.12
