### PR TITLE
Fix/otel gauge metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ Thumbs.db
 *.log
 *git_author=*
 diagram.png
+*.bak

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,16 @@
 # Release Notes
 
+## Version 0.0.14 (2025-06-04)
+
+### fix: Fixed OpenTelemetry metric recording with ObservableGauge
+
+- Fixed `'_Gauge' object has no attribute 'record'` error in OpenTelemetry metrics
+- Replaced `Gauge.record()` with individual `ObservableGauge` metrics and callbacks
+- Each metric now has its own ObservableGauge for better visualization in Instana
+- Added proper descriptions for each metric type
+- Improved error handling for non-numeric metrics
+- Enhanced debugging for metric observation and recording
+
 ## Version 0.0.13 (2025-06-02)
 
 ### feat: Installation testing and process simplification

--- a/TAG_v0.0.14.md
+++ b/TAG_v0.0.14.md
@@ -1,0 +1,30 @@
+# TAG v0.0.14
+
+## fix: Fixed OpenTelemetry metric recording with ObservableGauge
+
+This release fixes a critical issue with OpenTelemetry metric recording, specifically addressing the error:
+`'_Gauge' object has no attribute 'record'`
+
+### Changes
+
+- Replaced direct `Gauge.record()` calls with `ObservableGauge` and appropriate callbacks
+- Updated the metric recording system to store metrics in a state dictionary and observe them via callbacks
+- Each metric now has its own ObservableGauge with proper description for better visualization in Instana
+- Improved error handling for non-numeric metrics
+- Enhanced testing of the OpenTelemetry connector
+- Added comprehensive test cases for the new metric observation pattern
+- Updated release notes with detailed information about the fix
+
+### Impact
+
+This change makes the plugins compatible with the OpenTelemetry metric API, which requires using `ObservableGauge` with callbacks rather than directly recording values with `Gauge.record()`.
+
+### Affected Files
+
+- `common/otel_connector.py` - Major refactoring of the metric recording system
+- `tests/test_otel_connector.py` - Updated tests to verify the new implementation
+- `RELEASE_NOTES.md` - Added information about the fix
+
+### Contributors
+
+- Instana Plugins Team

--- a/m8mulprc/install-instana-m8mulprc-plugin.sh
+++ b/m8mulprc/install-instana-m8mulprc-plugin.sh
@@ -5,7 +5,7 @@
 # Copyright (c) 2025 laplaque/instana_plugins Contributors
 #
 # This file is part of the Instana Plugins collection.
-# Version: 0.0.13
+# Version: 0.0.14
 #
 
 # M8MulPrc Instana Plugin Installer

--- a/m8mulprc/sensor.py
+++ b/m8mulprc/sensor.py
@@ -6,7 +6,7 @@ MIT License
 Copyright (c) 2025 laplaque/instana_plugins Contributors
 
 This file is part of the Instana Plugins collection.
-Version: 0.0.13
+Version: 0.0.14
 """
 import sys
 import os
@@ -18,7 +18,7 @@ from common.base_sensor import run_sensor
 # Define the process name with proper capitalization
 PROCESS_NAME = "M8MulPrc"
 PLUGIN_NAME = "com.instana.plugin.python.microstrategy_m8mulprc"
-VERSION = "0.0.13"
+VERSION = "0.0.14"
 
 if __name__ == "__main__":
     run_sensor(PROCESS_NAME, PLUGIN_NAME, VERSION)

--- a/m8prcsvr/install-instana-m8prcsvr-plugin.sh
+++ b/m8prcsvr/install-instana-m8prcsvr-plugin.sh
@@ -5,7 +5,7 @@
 # Copyright (c) 2025 laplaque/instana_plugins Contributors
 #
 # This file is part of the Instana Plugins collection.
-# Version: 0.0.13
+# Version: 0.0.14
 #
 
 # M8PrcSvr Instana Plugin Installer

--- a/m8prcsvr/sensor.py
+++ b/m8prcsvr/sensor.py
@@ -3,7 +3,7 @@
 M8PrcSvr Sensor
 
 This module monitors the MicroStrategy M8PrcSvr process and reports metrics to Instana.
-Version: 0.0.13
+Version: 0.0.14
 """
 
 import sys
@@ -16,7 +16,7 @@ from common.base_sensor import run_sensor
 
 PROCESS_NAME = "M8PrcSvr"
 PLUGIN_NAME = "com.instana.plugin.python.microstrategy_m8prcsvr"
-VERSION = "0.0.13"
+VERSION = "0.0.14"
 
 if __name__ == "__main__":
     run_sensor(PROCESS_NAME, PLUGIN_NAME, VERSION)

--- a/m8refsvr/install-instana-m8refsvr-plugin.sh
+++ b/m8refsvr/install-instana-m8refsvr-plugin.sh
@@ -5,7 +5,7 @@
 # Copyright (c) 2025 laplaque/instana_plugins Contributors
 #
 # This file is part of the Instana Plugins collection.
-# Version: 0.0.13
+# Version: 0.0.14
 #
 
 # M8RefSvr Instana Plugin Installer

--- a/m8refsvr/sensor.py
+++ b/m8refsvr/sensor.py
@@ -6,7 +6,7 @@ MIT License
 Copyright (c) 2025 laplaque/instana_plugins Contributors
 
 This file is part of the Instana Plugins collection.
-Version: 0.0.13
+Version: 0.0.14
 """
 import sys
 import os
@@ -18,7 +18,7 @@ from common.base_sensor import run_sensor
 # Define the process name with proper capitalization
 PROCESS_NAME = "M8RefSvr"
 PLUGIN_NAME = "com.instana.plugin.python.microstrategy_m8refsvr"
-VERSION = "0.0.13"
+VERSION = "0.0.14"
 
 if __name__ == "__main__":
     run_sensor(PROCESS_NAME, PLUGIN_NAME, VERSION)

--- a/mstrsvr/install-instana-mstrsvr-plugin.sh
+++ b/mstrsvr/install-instana-mstrsvr-plugin.sh
@@ -5,7 +5,7 @@
 # Copyright (c) 2025 laplaque/instana_plugins Contributors
 #
 # This file is part of the Instana Plugins collection.
-# Version: 0.0.13
+# Version: 0.0.14
 #
 
 # MSTRSvr Instana Plugin Installer

--- a/mstrsvr/sensor.py
+++ b/mstrsvr/sensor.py
@@ -6,7 +6,7 @@ MIT License
 Copyright (c) 2025 laplaque/instana_plugins Contributors
 
 This file is part of the Instana Plugins collection.
-Version: 0.0.13
+Version: 0.0.14
 """
 import sys
 import os
@@ -18,7 +18,7 @@ from common.base_sensor import run_sensor
 # Define the process name with proper capitalization
 PROCESS_NAME = "MSTRSvr"
 PLUGIN_NAME = "com.instana.plugin.python.microstrategy_mstrsvr"
-VERSION = "0.0.13"
+VERSION = "0.0.14"
 
 if __name__ == "__main__":
     run_sensor(PROCESS_NAME, PLUGIN_NAME, VERSION)

--- a/tests/test_otel_connector.py
+++ b/tests/test_otel_connector.py
@@ -167,8 +167,10 @@ class TestInstanaOTelConnector(unittest.TestCase):
             agent_port=1234
         )
         
-        # Mock the meter
+        # Mock the meter and gauge
         connector.meter = MagicMock()
+        mock_gauge = MagicMock()
+        connector.meter.create_observable_gauge.return_value = mock_gauge
         
         # Call register_observable_metrics
         connector._register_observable_metrics()
@@ -183,6 +185,10 @@ class TestInstanaOTelConnector(unittest.TestCase):
         # Verify the number of calls to create_observable_gauge
         # +1 for the general metrics gauge
         self.assertEqual(connector.meter.create_observable_gauge.call_count, 
+                         len(expected_metrics) + 1)
+        
+        # Verify observe was called for each gauge (same number as create_observable_gauge)
+        self.assertEqual(mock_gauge.observe.call_count, 
                          len(expected_metrics) + 1)
         
         # Verify metrics were added to registry

--- a/tests/test_otel_connector.py
+++ b/tests/test_otel_connector.py
@@ -108,11 +108,6 @@ class TestInstanaOTelConnector(unittest.TestCase):
             agent_port=1234
         )
         
-        # Mock meter and gauge
-        connector.meter = MagicMock()
-        mock_gauge = MagicMock()
-        connector.meter.create_gauge.return_value = mock_gauge
-        
         # Test with numeric metrics
         metrics = {
             "cpu_usage": 10.5,
@@ -121,13 +116,10 @@ class TestInstanaOTelConnector(unittest.TestCase):
         }
         connector.record_metrics(metrics)
         
-        # Verify gauge creation and recording
-        self.assertEqual(connector.meter.create_gauge.call_count, 3)
-        self.assertEqual(mock_gauge.record.call_count, 3)
-        
-        # Reset mock counts for the next test
-        connector.meter.create_gauge.reset_mock()
-        mock_gauge.record.reset_mock()
+        # Verify metrics state was updated
+        self.assertEqual(connector._metrics_state["cpu_usage"], 10.5)
+        self.assertEqual(connector._metrics_state["memory_usage"], 20.3)
+        self.assertEqual(connector._metrics_state["process_count"], 3)
         
         # Test with string metrics
         metrics = {
@@ -136,10 +128,9 @@ class TestInstanaOTelConnector(unittest.TestCase):
         }
         connector.record_metrics(metrics)
         
-        # Verify gauge creation and recording (only for numeric string)
-        # Only one numeric string should be processed
-        self.assertEqual(connector.meter.create_gauge.call_count, 1)
-        self.assertEqual(mock_gauge.record.call_count, 1)
+        # Verify metrics state was updated for numeric string
+        self.assertEqual(connector._metrics_state["cpu_usage"], 10.5)
+        self.assertNotIn("non_numeric", connector._metrics_state)
 
     @patch.object(InstanaOTelConnector, '_setup_tracing')
     @patch.object(InstanaOTelConnector, '_setup_metrics')
@@ -166,6 +157,38 @@ class TestInstanaOTelConnector(unittest.TestCase):
         )
         self.assertEqual(span, mock_span)
 
+    @patch.object(InstanaOTelConnector, '_setup_tracing')
+    def test_register_observable_metrics(self, mock_setup_tracing):
+        """Test registering observable metrics."""
+        # Create connector with mocked meter
+        connector = InstanaOTelConnector(
+            service_name="test_service",
+            agent_host="test_host",
+            agent_port=1234
+        )
+        
+        # Mock the meter
+        connector.meter = MagicMock()
+        
+        # Call register_observable_metrics
+        connector._register_observable_metrics()
+        
+        # Verify create_observable_gauge was called for each expected metric
+        expected_metrics = [
+            "cpu_usage", "memory_usage", "process_count", "disk_read_bytes", 
+            "disk_write_bytes", "open_file_descriptors", "thread_count",
+            "voluntary_ctx_switches", "nonvoluntary_ctx_switches"
+        ]
+        
+        # Verify the number of calls to create_observable_gauge
+        # +1 for the general metrics gauge
+        self.assertEqual(connector.meter.create_observable_gauge.call_count, 
+                         len(expected_metrics) + 1)
+        
+        # Verify metrics were added to registry
+        for metric in expected_metrics:
+            self.assertIn(metric, connector._metrics_registry)
+    
     @patch.object(InstanaOTelConnector, '_setup_tracing')
     @patch.object(InstanaOTelConnector, '_setup_metrics')
     def test_shutdown(self, mock_setup_metrics, mock_setup_tracing):


### PR DESCRIPTION
# Bug Fix otel guage metrics
## Description
- Fixed `'_Gauge' object has no attribute 'record'` error in OpenTelemetry metrics
- Replaced `Gauge.record()` with individual `ObservableGauge` metrics and callbacks
- Each metric now has its own ObservableGauge for better visualization in Instana
- Added proper descriptions for each metric type
- Improved error handling for non-numeric metrics
- Enhanced debugging for metric observation and recording

## Checklist before requesting a review
- [/] I have performed a self-review of my code
- [/] If this is a merge to master, I will create a version tag (v*.*.*)
- [/] The version tag will be higher than the previous version

## Tag Information
<!-- If merging to master, include the tag you plan to create after merge -->
Planned tag: v0.0.14
