### PR TITLE
Fix observable gauge api

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,16 @@
 # Release Notes
 
+## Version 0.0.15 (2025-06-04)
+
+### fix: Updated ObservableGauge API usage for OpenTelemetry >= 1.20.0
+
+- Fixed `'_ObservableGauge' object has no attribute 'observe'` error
+- Updated implementation to use the newer OpenTelemetry API pattern
+- Changed to pass callbacks directly to create_observable_gauge method
+- Improved metric observation with proper callback parameter handling
+- Updated tests to match the new implementation pattern
+- Ensures compatibility with OpenTelemetry version 1.20.0 and newer
+
 ## Version 0.0.14 (2025-06-04)
 
 ### fix: Fixed OpenTelemetry metric recording with ObservableGauge

--- a/TAG_v0.0.15.md
+++ b/TAG_v0.0.15.md
@@ -1,0 +1,10 @@
+# TAG v0.0.15
+
+## fix: Updated ObservableGauge API usage for OpenTelemetry >= 1.20.0
+
+- Fixed `'_ObservableGauge' object has no attribute 'observe'` error
+- Updated implementation to use the newer OpenTelemetry API pattern
+- Changed to pass callbacks directly to create_observable_gauge method
+- Improved metric observation with proper callback parameter handling
+- Updated tests to match the new implementation pattern
+- Ensures compatibility with OpenTelemetry version 1.20.0 and newer

--- a/m8mulprc/install-instana-m8mulprc-plugin.sh
+++ b/m8mulprc/install-instana-m8mulprc-plugin.sh
@@ -5,7 +5,7 @@
 # Copyright (c) 2025 laplaque/instana_plugins Contributors
 #
 # This file is part of the Instana Plugins collection.
-# Version: 0.0.14
+# Version: 0.0.15
 #
 
 # M8MulPrc Instana Plugin Installer

--- a/m8mulprc/sensor.py
+++ b/m8mulprc/sensor.py
@@ -6,7 +6,7 @@ MIT License
 Copyright (c) 2025 laplaque/instana_plugins Contributors
 
 This file is part of the Instana Plugins collection.
-Version: 0.0.14
+Version: 0.0.15
 """
 import sys
 import os
@@ -18,7 +18,7 @@ from common.base_sensor import run_sensor
 # Define the process name with proper capitalization
 PROCESS_NAME = "M8MulPrc"
 PLUGIN_NAME = "com.instana.plugin.python.microstrategy_m8mulprc"
-VERSION = "0.0.14"
+VERSION = "0.0.15"
 
 if __name__ == "__main__":
     run_sensor(PROCESS_NAME, PLUGIN_NAME, VERSION)

--- a/m8prcsvr/install-instana-m8prcsvr-plugin.sh
+++ b/m8prcsvr/install-instana-m8prcsvr-plugin.sh
@@ -5,7 +5,7 @@
 # Copyright (c) 2025 laplaque/instana_plugins Contributors
 #
 # This file is part of the Instana Plugins collection.
-# Version: 0.0.14
+# Version: 0.0.15
 #
 
 # M8PrcSvr Instana Plugin Installer

--- a/m8prcsvr/sensor.py
+++ b/m8prcsvr/sensor.py
@@ -3,7 +3,7 @@
 M8PrcSvr Sensor
 
 This module monitors the MicroStrategy M8PrcSvr process and reports metrics to Instana.
-Version: 0.0.14
+Version: 0.0.15
 """
 
 import sys
@@ -16,7 +16,7 @@ from common.base_sensor import run_sensor
 
 PROCESS_NAME = "M8PrcSvr"
 PLUGIN_NAME = "com.instana.plugin.python.microstrategy_m8prcsvr"
-VERSION = "0.0.14"
+VERSION = "0.0.15"
 
 if __name__ == "__main__":
     run_sensor(PROCESS_NAME, PLUGIN_NAME, VERSION)

--- a/m8refsvr/install-instana-m8refsvr-plugin.sh
+++ b/m8refsvr/install-instana-m8refsvr-plugin.sh
@@ -5,7 +5,7 @@
 # Copyright (c) 2025 laplaque/instana_plugins Contributors
 #
 # This file is part of the Instana Plugins collection.
-# Version: 0.0.14
+# Version: 0.0.15
 #
 
 # M8RefSvr Instana Plugin Installer

--- a/m8refsvr/sensor.py
+++ b/m8refsvr/sensor.py
@@ -6,7 +6,7 @@ MIT License
 Copyright (c) 2025 laplaque/instana_plugins Contributors
 
 This file is part of the Instana Plugins collection.
-Version: 0.0.14
+Version: 0.0.15
 """
 import sys
 import os
@@ -18,7 +18,7 @@ from common.base_sensor import run_sensor
 # Define the process name with proper capitalization
 PROCESS_NAME = "M8RefSvr"
 PLUGIN_NAME = "com.instana.plugin.python.microstrategy_m8refsvr"
-VERSION = "0.0.14"
+VERSION = "0.0.15"
 
 if __name__ == "__main__":
     run_sensor(PROCESS_NAME, PLUGIN_NAME, VERSION)

--- a/mstrsvr/install-instana-mstrsvr-plugin.sh
+++ b/mstrsvr/install-instana-mstrsvr-plugin.sh
@@ -5,7 +5,7 @@
 # Copyright (c) 2025 laplaque/instana_plugins Contributors
 #
 # This file is part of the Instana Plugins collection.
-# Version: 0.0.14
+# Version: 0.0.15
 #
 
 # MSTRSvr Instana Plugin Installer

--- a/mstrsvr/sensor.py
+++ b/mstrsvr/sensor.py
@@ -6,7 +6,7 @@ MIT License
 Copyright (c) 2025 laplaque/instana_plugins Contributors
 
 This file is part of the Instana Plugins collection.
-Version: 0.0.14
+Version: 0.0.15
 """
 import sys
 import os
@@ -18,7 +18,7 @@ from common.base_sensor import run_sensor
 # Define the process name with proper capitalization
 PROCESS_NAME = "MSTRSvr"
 PLUGIN_NAME = "com.instana.plugin.python.microstrategy_mstrsvr"
-VERSION = "0.0.14"
+VERSION = "0.0.15"
 
 if __name__ == "__main__":
     run_sensor(PROCESS_NAME, PLUGIN_NAME, VERSION)

--- a/tests/test_otel_connector.py
+++ b/tests/test_otel_connector.py
@@ -187,13 +187,16 @@ class TestInstanaOTelConnector(unittest.TestCase):
         self.assertEqual(connector.meter.create_observable_gauge.call_count, 
                          len(expected_metrics) + 1)
         
-        # Verify observe was called for each gauge (same number as create_observable_gauge)
-        self.assertEqual(mock_gauge.observe.call_count, 
-                         len(expected_metrics) + 1)
-        
         # Verify metrics were added to registry
         for metric in expected_metrics:
             self.assertIn(metric, connector._metrics_registry)
+            
+        # Verify each call to create_observable_gauge includes callbacks parameter
+        for call_args in connector.meter.create_observable_gauge.call_args_list:
+            args, kwargs = call_args
+            self.assertIn('callbacks', kwargs)
+            self.assertIsInstance(kwargs['callbacks'], list)
+            self.assertTrue(len(kwargs['callbacks']) > 0)
     
     @patch.object(InstanaOTelConnector, '_setup_tracing')
     @patch.object(InstanaOTelConnector, '_setup_metrics')


### PR DESCRIPTION
# Fix observable gauge api
## Description
- Fixed `'_ObservableGauge' object has no attribute 'observe'` error
- Updated implementation to use the newer OpenTelemetry API pattern
- Changed to pass callbacks directly to create_observable_gauge method
- Improved metric observation with proper callback parameter handling
- Updated tests to match the new implementation pattern
- Ensures compatibility with OpenTelemetry version 1.20.0 and newer

## Checklist before requesting a review
- [/] I have performed a self-review of my code
- [/] If this is a merge to master, I will create a version tag (v*.*.*)
- [/] The version tag will be higher than the previous version

## Tag Information
<!-- If merging to master, include the tag you plan to create after merge -->
Planned tag: v0.0.15
