### PR TITLE
Fix logging configuration to ensure logs directory exists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ Thumbs.db
 *git_author=*
 diagram.png
 *.bak
+
+# Logs directory - keep the directory but ignore log files
+logs/*.log
+logs/*.log.*

--- a/common/base_sensor.py
+++ b/common/base_sensor.py
@@ -41,6 +41,8 @@ def parse_args(description):
     parser.add_argument('--log-level', default='INFO',
                         choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
                         help='Set the logging level (default: INFO)')
+    parser.add_argument('--log-file', 
+                        help='Path to the log file (default: project_root/logs/app.log)')
     return parser.parse_args()
 
 def monitor_process(process_name, plugin_name, agent_host, agent_port, interval=60, run_once=False):
@@ -110,8 +112,11 @@ def run_sensor(process_name, plugin_name, version):
     """Main entry point for sensor scripts"""
     args = parse_args(f'Monitor {process_name} process metrics for Instana')
     
-    # Set the log level
-    logging.getLogger().setLevel(getattr(logging, args.log_level))
+    # Set up logging with the specified log file if provided
+    setup_logging(
+        log_level=getattr(logging, args.log_level),
+        log_file=args.log_file
+    )
     
     logger.info(f"Starting {plugin_name} v{version} with Instana agent at {args.agent_host}:{args.agent_port}")
     

--- a/common/logging_config.py
+++ b/common/logging_config.py
@@ -2,14 +2,20 @@ import logging
 import os
 from logging.handlers import RotatingFileHandler
 
-def setup_logging(log_level=logging.INFO, log_file='app.log'):
+def setup_logging(log_level=logging.INFO, log_file=None):
     """
     Setup logging configuration with file and console handlers.
     
     Args:
         log_level: The logging level (default: logging.INFO)
-        log_file: Path to the log file (default: 'app.log')
+        log_file: Path to the log file (default: None, which will use project_root/logs/app.log)
     """
+    # Determine the default log file path if not provided
+    if log_file is None:
+        # Get the project root directory (2 levels up from this file)
+        project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+        log_dir = os.path.join(project_root, 'logs')
+        log_file = os.path.join(log_dir, 'app.log')
     # Create formatter
     formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
     
@@ -28,6 +34,11 @@ def setup_logging(log_level=logging.INFO, log_file='app.log'):
     
     # Add file handler with rotation
     try:
+        # Create directory for log file if it doesn't exist
+        log_dir = os.path.dirname(os.path.abspath(log_file))
+        if log_dir and not os.path.exists(log_dir):
+            os.makedirs(log_dir)
+            
         file_handler = RotatingFileHandler(
             log_file,
             maxBytes=5 * 1024 * 1024,  # 5 MB
@@ -36,6 +47,7 @@ def setup_logging(log_level=logging.INFO, log_file='app.log'):
         )
         file_handler.setFormatter(formatter)
         root_logger.addHandler(file_handler)
+        root_logger.info(f"Logging to file: {log_file}")
     except Exception as e:
         console_handler.setLevel(logging.WARNING)
         root_logger.warning(f"Could not create log file at {log_file}: {e}")


### PR DESCRIPTION
# Fix: logging configuration to ensure logs directory exists

## Description
This commit improves the logging system by:
- Creating the logs directory if it doesn't exist
- Setting default log path to project_root/logs/app.log
- Making log file path configurable via --log-file command line argument
- Updating .gitignore to exclude log files but track the logs directory

## Checklist before requesting a review
- [/] I have performed a self-review of my code
- [/] If this is a merge to master, I will create a version tag (v*.*.*)
- [/] The version tag will be higher than the previous version

## Tag Information
<!-- If merging to master, include the tag you plan to create after merge -->
Planned tag: v0.0.17
